### PR TITLE
Add support for processing eAPI revisions of commands

### DIFF
--- a/AristaLibrary/AristaLibrary.py
+++ b/AristaLibrary/AristaLibrary.py
@@ -731,3 +731,31 @@ class AristaLibrary(object):
         if loss_percent == '100':
             return False
         return True
+
+    def eapi_command(self, cmd, revision=None):
+        """
+        Returns a properly formatted JSON object for an eAPI command with an
+        optionally-specified output revision.
+
+        Arguments:
+        - `cmd`: A text string containing the EOS command to execute
+        - `revision`: (Optional) The desired output revision
+
+        Example:
+        | ${commands}=       | eapi Command    | show cvx    | revision=2 |
+        | Log List           | ${commands}     | level=DEBUG |            |
+        | Get Command Output | cmd=${commands} |             |            |
+        | Expect             | clusterMode     | is          | False      |
+
+        | ${command1}= | eapi Command | show cvx    | revision=2  |
+        | ${command2}= | show version |             |             |
+        | ${commands}= | Create List  | ${command1} | ${command2} |
+        | Log List     | ${commands}  | level=DEBUG |             |
+        | ${output}=   | Enable       | ${commands} |             |
+        """
+        command = {}
+        command['cmd'] = str(cmd)
+        if revision is not None:
+            command['revision'] = int(revision)
+
+        return [command]

--- a/AristaLibrary/Expect.py
+++ b/AristaLibrary/Expect.py
@@ -264,32 +264,38 @@ class Expect(object):
 
             self.arista_lib.change_to_switch(index)
 
-            # if self.import_cmd and re.match(r'^show running-config all', self.import_cmd):
-            if run_cmd == 'show startup-config':
-                # Command is 'show startup-config'. Get the startup config
-                # from the AristaLibrary object after refreshing the
-                # state of the configs stored in the object.
-                self.arista_lib.refresh()
-                reply = self.arista_lib.get_startup_config()
-                self.result[index] = reply.split('\n')
-            elif run_cmd == 'show running-config all':
-                # Command is 'show running-config all'. Get the running config
-                # from the AristaLibrary object after refreshing the
-                # state of the configs stored in the object.
-                self.arista_lib.refresh()
-                reply = self.arista_lib.get_running_config()
-                self.result[index] = reply.split('\n')
-            elif re.match(r'^show (startup|running)-config.*$', run_cmd):
-                # Command is a 'show *-config' that does not map directly
-                # to an AristaLibrary object attribute. Send the command
-                # to the switch and store the reply as a list.
-                reply = self.arista_lib.enable(run_cmd, encoding='text')
-                self.result[index] = reply[0]['result']['output'].split('\n')
-            elif run_cmd:
+            if isinstance(run_cmd, dict) or isinstance(run_cmd, list):
                 # Command is user specified. Send the command to the switch
                 # and store the result as a dictionary.
                 reply = self.arista_lib.enable(run_cmd)
                 self.result[index] = reply[0]['result']
+            else:
+                # Command is a string. See if it matches a special case
+                if run_cmd == 'show startup-config':
+                    # Command is 'show startup-config'. Get the startup config
+                    # from the AristaLibrary object after refreshing the
+                    # state of the configs stored in the object.
+                    self.arista_lib.refresh()
+                    reply = self.arista_lib.get_startup_config()
+                    self.result[index] = reply.split('\n')
+                elif run_cmd == 'show running-config all':
+                    # Command is 'show running-config all'. Get the running config
+                    # from the AristaLibrary object after refreshing the
+                    # state of the configs stored in the object.
+                    self.arista_lib.refresh()
+                    reply = self.arista_lib.get_running_config()
+                    self.result[index] = reply.split('\n')
+                elif re.match(r'^show (startup|running)-config.*$', run_cmd):
+                    # Command is a 'show *-config' that does not map directly
+                    # to an AristaLibrary object attribute. Send the command
+                    # to the switch and store the reply as a list.
+                    reply = self.arista_lib.enable(run_cmd, encoding='text')
+                    self.result[index] = reply[0]['result']['output'].split('\n')
+                elif run_cmd:
+                    # Command is user specified. Send the command to the switch
+                    # and store the result as a dictionary.
+                    reply = self.arista_lib.enable(run_cmd)
+                    self.result[index] = reply[0]['result']
 
         return self.result
 

--- a/AristaLibrary/__init__.py
+++ b/AristaLibrary/__init__.py
@@ -21,6 +21,8 @@
 # "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 # LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
 # A PARTICULAR PURPOSE ARE DISCLAIMED. IN
-from version import VERSION
+""" Top-level imports for AristLibrary
+"""
+from .version import VERSION
 __version__ = VERSION
-from AristaLibrary import *  # NOQA
+from .AristaLibrary import *  # NOQA

--- a/atest/AristaLibrary/BDD_style.rst
+++ b/atest/AristaLibrary/BDD_style.rst
@@ -1,0 +1,138 @@
+============================================
+Simple Test Example usign BDD style keywords
+============================================
+
+.. raw:: html
+
+   <!-- This class allows us to hide the test setup part -->
+   <style type="text/css">.hidden { display: none; }</style>
+
+.. contents::
+    :local:
+
+This example demonstrates how RobotFramework tests can be embedded in
+ReStructuredText documentation and use the Behavior Driven Development (BDD)
+(gherkin) style language.  If you are converting an existing tab-separated test
+suite, convert tabs to 4-spaces within the RST file.
+
+“Given”, “When”, “Then” and “And” are ignored at the beginning of user keywords.
+
+See http://robotframework.googlecode.com/svn/tags/robotframework-2.1.2/doc/userguide/RobotFrameworkUserGuide.html#embedding-arguments-into-keyword-name
+
+The testcases should be in `code:: robotframework` blocks.
+
+Installing RobotFramework
+=========================
+
+To execute this test, setup the following::
+
+    pip install robotframework docutils Pygments
+    git clone https://github.com/arista-eosplus/robotframework-aristalibrary.git
+    cd robotframework-aristalibrary/
+    python setup.py install
+
+
+Executing tests
+===============
+
+Start tests using one of the examples, below::
+
+    robot demo/sample_test_refactored.rst
+
+    robot --variable SW1_HOST:localhost --variable SW1_PORT:61080 \
+          --variable USERNAME:eapiuser --variable PASSWORD:icanttellyou \
+          demo/sample_test_refactored.rst
+
+    robot --variablefile demo/myvariables.py
+          demo/sample_test_refactored.rst
+
+Variable files
+--------------
+
+Variable files are just python modules with KEY = value pairs.
+
+Example `myvariables.py`::
+
+    """ My custom values for this test suite
+    """
+
+    SW1_HOST = 'localhost'
+    SW1_PORT = 61080
+    USERNAME = 'eapiuser'
+    PASSWORD = 'icanttellyou'
+
+Suite Setup
+===========
+
+.. code:: robotframework
+   :class: hidden
+
+    *** Settings ***
+    Documentation    This is a sample Robot Framework suite which takes advantage of
+    ...    the AristaLibrary for communicating with and controlling Arista switches.
+    ...    Run with:
+    ...    pybot --pythonpath=AristaLibrary --noncritical new demo/sample-test-refactored.txt
+
+    Library    AristaLibrary
+    Library    Collections
+    Suite Setup    Connect To Switches
+    Suite Teardown    Clear All Connections
+
+    *** Variables ***
+    ${TRANSPORT}    http
+    ${SW1_HOST}    localhost
+    ${SW1_PORT}    2080
+    ${SW2_HOST}    localhost
+    ${SW2_PORT}    2081
+    ${USERNAME}    vagrant
+    ${PASSWORD}    vagrant
+
+    *** Keywords ***
+    Connect To Switches
+        [Documentation]    Establish connection to a switch which gets used by test cases.
+        Connect To    host=${SW1_HOST}    transport=${TRANSPORT}    username=${USERNAME}    password=${PASSWORD}    port=${SW1_PORT}
+        Configure    hostname veos0
+        #Connect To    host=${SW2_HOST}    transport=${TRANSPORT}    username=${USERNAME}    password=${PASSWORD}    port=${SW2_PORT}
+        #Configure    hostname veos1
+
+    Configure IP Int
+        [Arguments]    ${switch}    ${interface}    ${ip}
+        Change To Switch    ${switch}
+        Configure    default interface ${interface}
+        @{cmds}=    Create List    default interface ${interface}    interface ${interface}    no switchport    ip address ${ip}    no shutdown
+        Configure    ${cmds}
+
+    Switch ${switch} interface ${interface} has ip ${ip}
+        Configure IP Int    ${switch}    ${interface}    ${ip}
+
+    Switch ${switch} pings ${ip}
+        ${output}=    Enable    ping 10.1.1.0    text
+        ${result}=    Get From Dictionary    ${output[0]}    result
+        Log    ${result}
+        ${match}    ${group1}=    Should Match Regexp    ${result['output']}    (\\d+)% packet loss
+        Set Suite Variable    ${PING_RESULT}    ${group1}
+
+    ping packet loss should be ${expected}
+        ${result} =    Get Variable Value   ${PING_RESULT}    "No_data"
+        Should Be Equal As Integers    ${result}    ${expected}    msg="Packets lost percent is ${result}, not ${expected}!!!"
+        Set Suite Variable    ${PING_RESULT}    ${EMPTY}
+
+
+Test Cases
+===============
+
+.. code:: robotframework
+
+    *** Test Cases ***
+    BDD Style Ping Self
+        Given switch 1 interface Ethernet1 has ip 10.1.1.0/31
+        When switch 1 pings 10.1.1.0
+        Then ping packet loss should be 0
+
+    #BDD Style Ping Peer
+    #    Given switch 1 interface Ethernet1 has ip 10.1.1.0/31
+    #    And switch 2 interface Ethernet1 has ip 10.1.1.1/31
+    #    When switch 2 pings 10.1.1.0
+    #    Then ping packet loss should be 0
+
+There you go...  Tests, embedded within documentation!

--- a/atest/AristaLibrary/eapi_cmd_revisions.rst
+++ b/atest/AristaLibrary/eapi_cmd_revisions.rst
@@ -1,0 +1,128 @@
+========================================
+Sample Test Example in RST documentation
+========================================
+
+.. raw:: html
+
+   <!-- This class allows us to hide the test setup part -->
+   <style type="text/css">.hidden { display: none; }</style>
+
+.. contents::
+    :local:
+
+This example demonstrates how RobotFramework tests can be embedded in
+ReStructuredText documentation.  If you are converting an existing
+tab-separated test suite, convert tabs to 4-spaces within the RST file.
+
+The testcases should be in `code:: robotframework` blocks.
+
+Installing RobotFramework
+=========================
+
+To execute this test, setup the following::
+
+    pip install robotframework docutils Pygments
+    git clone https://github.com/arista-eosplus/robotframework-aristalibrary.git
+    cd robotframework-aristalibrary/
+    python setup.py install
+
+
+Executing tests
+===============
+
+Start tests using one of the examples, below::
+
+    robot demo/sample_test_refactored.rst
+
+    robot --variable SW1_HOST:localhost --variable SW1_PORT:61080 \
+          --variable USERNAME:eapiuser --variable PASSWORD:icanttellyou \
+          demo/sample_test_refactored.rst
+
+    robot --variablefile demo/myvariables.py
+          demo/sample_test_refactored.rst
+
+Variable files
+--------------
+
+Variable files are just python modules with KEY = value pairs.
+
+Example `myvariables.py`::
+
+    """ My custom values for this test suite
+    """
+
+    SW1_HOST = 'localhost'
+    SW1_PORT = 61080
+    USERNAME = 'eapiuser'
+    PASSWORD = 'icanttellyou'
+
+Suite Setup
+===========
+
+.. code:: robotframework
+   :class: hidden
+
+    *** Settings ***
+    Documentation    This is a sample Robot Framework suite which takes advantage of
+    ...    the AristaLibrary for communicating with and controlling Arista switches.
+    ...    Run with:
+    ...    pybot --pythonpath=AristaLibrary --noncritical new demo/sample-test-refactored.txt
+
+    Library    AristaLibrary
+    Library    AristaLibrary.Expect
+    Library    Collections
+    Suite Setup    Connect To Switches
+    Suite Teardown    Clear All Connections
+
+    *** Variables ***
+    ${TRANSPORT}    http
+    ${SW1_HOST}    localhost
+    ${SW1_PORT}    2080
+    ${SW2_HOST}    localhost
+    ${SW2_PORT}    2081
+    ${USERNAME}    vagrant
+    ${PASSWORD}    vagrant
+
+    *** Keywords ***
+    Connect To Switches
+        [Documentation]    Establish connection to a switch which gets used by test cases.
+        Connect To    host=${SW1_HOST}    transport=${TRANSPORT}    username=${USERNAME}    password=${PASSWORD}    port=${SW1_PORT}
+        Configure    hostname veos0
+        #Connect To    host=${SW2_HOST}    transport=${TRANSPORT}    username=${USERNAME}    password=${PASSWORD}    port=${SW2_PORT}
+        #Configure    hostname veos1
+
+Test Cases
+===============
+
+.. code:: robotframework
+
+    *** Test Cases ***
+    eAPI Command Revision
+        [tags]    Production
+
+        # Default revision
+        ${output}=    Enable    show cvx
+        ${result}=    Get From Dictionary    ${output[0]}    result
+        Log    ${result}
+        Dictionary Should Not Contain Key  ${result}  clusterMode
+
+        # Specify revision 2 for this command
+        ${show_cvx}=  Create Dictionary  cmd=show cvx  revision=${2}
+        ${cmds}=  Create List  ${show_cvx}
+        Log List  ${cmds}
+        ${output}=    Enable    ${cmds}
+        ${result}=    Get From Dictionary    ${output[0]}    result
+        Log    ${result}
+        Dictionary Should Contain Key  ${result}  clusterMode
+
+    eAPI Command Revision with Expect
+        [tags]    Production
+
+        # Specify revision 2 for this command
+        ${show_cvx}=  Create Dictionary  cmd=show cvx  revision=${2}
+        ${cmds}=  Create List  ${show_cvx}
+        Log List  ${cmds}
+        Get Command Output  cmd=${cmds}
+        Expect  clusterMode  is  False
+
+There you go...  Tests, embedded within documentation!

--- a/atest/AristaLibrary/eapi_cmd_revisions.rst
+++ b/atest/AristaLibrary/eapi_cmd_revisions.rst
@@ -125,4 +125,24 @@ Test Cases
         Get Command Output  cmd=${cmds}
         Expect  clusterMode  is  False
 
+    eAPI Command Revision with Eapi Command
+        [tags]    Production
+
+        ${show_cvx2}=  Create Dictionary  cmd=show cvx  revision=${2}
+        ${cmds2}=  Create List  ${show_cvx2}
+
+        # Specify revision 2 for this command
+        ${show_cvx}=  Eapi Command  cmd=show cvx  revision=2
+        ${show_ver}=  Eapi Command  cmd=show version
+        ${cmds}=  Combine Lists  ${show_cvx}  ${show_ver}
+        Log List  ${cmds}
+        Log List  ${show_cvx}
+        Log List  ${cmds2}
+
+        #Dictionaries Should Be Equal  ${show_cvx}[0]  ${show_cvx2}[0]
+        Lists Should Be Equal  ${show_cvx}  ${cmds2}
+        ${output}=    Enable    ${cmds}
+        Log List    ${output}
+        Log Dictionary    ${output[0]['result']}
+
 There you go...  Tests, embedded within documentation!

--- a/demo/sample-test-txt.txt
+++ b/demo/sample-test-txt.txt
@@ -1,0 +1,44 @@
+*** Settings ***
+Documentation     This is a sample Robot Framework suite which takes advantage of
+...               the AristaLibrary for communicating with and controlling Arista switches.
+...               Run with:
+...               pybot --pythonpath=AristaLibrary --noncritical new demo/sample-test.txt
+Suite Setup       Connect To Switches
+Suite Teardown    Clear All Connections
+Library           AristaLibrary
+Library           Collections
+
+*** Variables ***
+${TRANSPORT}      http
+${SW1_HOST}       localhost
+${SW1_PORT}       2080
+${SW2_HOST}       localhost
+${SW2_PORT}       2081
+${USERNAME}       vagrant
+${PASSWORD}       vagrant
+
+*** Test Cases ***
+Ping Test
+    [Documentation]    Configure Et1 on both nodes and ping between them
+    [Tags]    Configure
+    Change To Switch    1
+    Configure    default interface ethernet1
+    @{cmds}=    Create List    interface ethernet1    no switchport    ip address 10.1.1.0/31    no shutdown
+    Configure    ${cmds}
+    Change To Switch    2
+    Configure    default interface ethernet1
+    @{cmds}=    Create List    interface ethernet1    no switchport    ip address 10.1.1.1/31    no shutdown
+    Configure    ${cmds}
+    ${output}=    Enable    ping 10.1.1.0
+    ${result}=    Get From Dictionary    ${output[0]}    result
+    Log    ${result}
+    ${match}    ${group1}=    Should Match Regexp    ${result['messages'][0]}    (\\d+)% packet loss
+    Should Be Equal As Integers    ${group1}    0    msg="Packets lost!!!"
+
+*** Keywords ***
+Connect To Switches
+    [Documentation]    Establish connection to a switch which gets used by test cases.
+    Connect To    host=${SW1_HOST}    transport=${TRANSPORT}    username=${USERNAME}    password=${PASSWORD}    port=${SW1_PORT}
+    Configure    hostname veos0
+    Connect To    host=${SW2_HOST}    transport=${TRANSPORT}    username=${USERNAME}    password=${PASSWORD}    port=${SW2_PORT}
+    Configure    hostname veos1

--- a/demo/sample-test.tsv
+++ b/demo/sample-test.tsv
@@ -1,0 +1,42 @@
+*Settings*							
+Documentation	This is a sample Robot Framework suite which takes advantage of						
+...	the AristaLibrary for communicating with and controlling Arista switches.						
+...	Run with:						
+...	pybot --pythonpath=AristaLibrary --noncritical new demo/sample-test.txt						
+Suite Setup	Connect To Switches						
+Suite Teardown	Clear All Connections						
+Library	AristaLibrary						
+Library	Collections						
+							
+*Variables*							
+${TRANSPORT}	http						
+${SW1_HOST}	localhost						
+${SW1_PORT}	2080						
+${SW2_HOST}	localhost						
+${SW2_PORT}	2081						
+${USERNAME}	vagrant						
+${PASSWORD}	vagrant						
+							
+*Test Cases*							
+Ping Test	[Documentation]	Configure Et1 on both nodes and ping between them					
+	[Tags]	Configure					
+	Change To Switch	1					
+	Configure	default interface ethernet1					
+	@{cmds}=	Create List	interface ethernet1	no switchport	ip address 10.1.1.0/31	no shutdown	
+	Configure	${cmds}					
+	Change To Switch	2					
+	Configure	default interface ethernet1					
+	@{cmds}=	Create List	interface ethernet1	no switchport	ip address 10.1.1.1/31	no shutdown	
+	Configure	${cmds}					
+	${output}=	Enable	ping 10.1.1.0				
+	${result}=	Get From Dictionary	${output[0]}	result			
+	Log	${result}					
+	${match}	${group1}=	Should Match Regexp	${result['messages'][0]}	(\\d+)% packet loss		
+	Should Be Equal As Integers	${group1}	0	"msg=""Packets lost!!!"""			
+							
+*Keywords*							
+Connect To Switches	[Documentation]	Establish connection to a switch which gets used by test cases.					
+	Connect To	host=${SW1_HOST}	transport=${TRANSPORT}	username=${USERNAME}	password=${PASSWORD}	port=${SW1_PORT}	
+	Configure	hostname veos0					
+	Connect To	host=${SW2_HOST}	transport=${TRANSPORT}	username=${USERNAME}	password=${PASSWORD}	port=${SW2_PORT}	
+	Configure	hostname veos1					

--- a/demo/sample_test_using_BDD.rst
+++ b/demo/sample_test_using_BDD.rst
@@ -73,7 +73,7 @@ Suite Setup
     ...    Run with:
     ...    pybot --pythonpath=AristaLibrary --noncritical new demo/sample-test-refactored.txt
 
-    Library    AristaLibrary.py
+    Library    AristaLibrary
     Library    Collections
     Suite Setup    Connect To Switches
     Suite Teardown    Clear All Connections


### PR DESCRIPTION
Fixes #21 

Usage requires a list of oen or more commands where each command be properly formatted JSON and revision must be numeric, not a string: Ex: `[{'cmd'='show cvx', 'revision'=2}]`  The list may contain a mix of command strings and JSON format, as needed: `['show version', {'cmd'='show cvx', 'revision'=2}]`  There are 2 ways to build the command object, below.
```
    *** Settings ***
    Library    AristaLibrary
    Library    AristaLibrary.Expect

    *** Test Cases ***
  eAPI Command Revision with Eapi Command
        # Specify revision 2 for this command
        ${show_cvx}=  Eapi Command  cmd=show cvx  revision=2
        # Default to revision 1 for this command
        ${show_ver}=  Eapi Command  cmd=show version
        ${cmds}=  Combine Lists  ${show_cvx}  ${show_ver}
        ${output}=    Enable    ${cmds}
        Log Dictionary    ${output[0]['result']}
        Log Dictionary    ${output[1]['result']}

  eAPI Command Revision with Create Dictionary + Create List
        [tags]    Production
        # Specify revision 2 for this command
        ${show_cvx}=  Create Dictionary  cmd=show cvx  revision=${2}
        ${cmds}=  Create List  ${show_cvx}
        Log List  ${cmds}
        Get Command Output  cmd=${cmds}
        Expect  clusterMode  is  False
```
