### PR TITLE
Minimal python2/3 compatible support

### DIFF
--- a/AristaLibrary/AristaLibrary.py
+++ b/AristaLibrary/AristaLibrary.py
@@ -615,7 +615,7 @@ class AristaLibrary(object):
                 elif not available and data['presence'] == 'present':
                     continue
 
-                if installed and data['status'] is not 'installed':
+                if installed and data['status'] != 'installed':
                     continue
                 elif installed == "forced" and data['status'] != \
                         'forceInstalled':

--- a/AristaLibrary/AristaLibrary.py
+++ b/AristaLibrary/AristaLibrary.py
@@ -35,8 +35,14 @@ from pyeapi.eapilib import CommandError
 from pyeapi.utils import make_iterable
 from robot.api import logger
 from robot.utils import ConnectionCache
-from version import VERSION
+from .version import VERSION
 import re
+import sys
+
+# Python3 compatible magic
+if sys.version_info[0] == 3:
+    unicode = str
+    basestring = (str, bytes)
 
 
 class AristaLibrary(object):
@@ -266,7 +272,7 @@ class AristaLibrary(object):
         | Log             | First switch connected to port ${switch_info[0]['port']} |      |
         """
         return_value = list()
-        for indx, values in self.connections.items():
+        for indx, values in list(self.connections.items()):
             return_value.append(values)
         return return_value
 
@@ -603,7 +609,7 @@ class AristaLibrary(object):
         if out['encoding'] == 'json':
             extensions = out['result']['extensions']
             filtered = []
-            for ext, data in extensions.items():
+            for ext, data in list(extensions.items()):
                 if available and data['presence'] != 'present':
                     continue
                 elif not available and data['presence'] == 'present':

--- a/AristaLibrary/Expect.py
+++ b/AristaLibrary/Expect.py
@@ -857,7 +857,7 @@ class Expect(object):
                 )
         elif isinstance(returned, list):
             # If we have a list, fail if the match value is not in the list
-            regex = re.compile("\s*{}".format(match))
+            regex = re.compile(r"\s*{}".format(match))
             matches = [m.group(0) for line in returned for m in
                        [regex.search(line)] if m]
             if not matches:

--- a/AristaLibrary/Expect.py
+++ b/AristaLibrary/Expect.py
@@ -32,7 +32,13 @@
 import re
 import logging
 from robot.libraries.BuiltIn import BuiltIn, RobotNotRunningError
-from version import VERSION
+from .version import VERSION
+import sys
+
+# Python3 compatible magic
+if sys.version_info[0] == 3:
+    unicode = str
+    basestring = (str, bytes)
 
 AE_ERR = 'AristaLibrary.Expect: '       # Arista Expect Error prefix
 
@@ -782,7 +788,7 @@ class Expect(object):
             if match not in returned:
                 raise RuntimeError(
                     msg or '{}Did not find key \'{}\' in \'{}\''.format(
-                        AE_ERR, match, returned.keys())
+                        AE_ERR, match, list(returned.keys()))
                 )
         else:
             # Not sure what type of return value we have
@@ -821,7 +827,7 @@ class Expect(object):
             if match in returned:
                 raise RuntimeError(
                     msg or '{}Found key \'{}\' in \'{}\''.format(
-                        AE_ERR, match, returned.keys())
+                        AE_ERR, match, list(returned.keys()))
                 )
         else:
             # Not sure what type of return value we have

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,9 @@ from os.path import abspath, dirname, join
 CURDIR = dirname(abspath(__file__))
 
 #from AristaLibrary import __version__, __author__
-execfile(join(CURDIR, 'AristaLibrary', 'version.py'))
+with open(join(CURDIR, 'AristaLibrary', 'version.py')) as version:
+    exec(version.read())
+
 with open(join(CURDIR, 'README.rst')) as readme:
     README = readme.read()
 


### PR DESCRIPTION
Fixed #32 and some python3 problems.

- Python3 is not support `execfile` in setup.py. Convert to compatible format.
- Fix generic differences in python 2 and 3. (some fixes used alias)
- No change docs